### PR TITLE
Add a warning to the generators page about operating turbines outside recommended limits

### DIFF
--- a/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
+++ b/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
@@ -18,6 +18,11 @@ TDB
 | HV | 4000 | 5000
 |===
 
+
+### Efficiency notice:
+For maximum power generation efficiency, please operate this equipment within specified limits as described in the installer's manual.
+Failure to operate this equipment within documented limits will significantly reduce power generation capability and void the warranty.
+
 ## Variants:
 ### LV
 

--- a/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
+++ b/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
@@ -22,7 +22,7 @@ TDB
 ### Efficiency notice:
 These machines will not produce specification power if run outside optimal RPM limits, see the above "RPM Sweetspots" table.
 
-For instance, the MV generator will not produce specification power if the RPM exceeds ~3200 or falls below 3100 based on version 2.1.8 hardware. Running a MV generator at 5000 RPM will produce no power at all.
+For instance, the MV generator will not produce specified power if the RPM exceeds ~3200 or falls below 3100 based on version 2.1.8 hardware. Running a MV generator at 5000 RPM will produce no power at all.
 
 
 ## Variants:

--- a/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
+++ b/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
@@ -20,7 +20,10 @@ TDB
 
 
 ### Efficiency notice:
-These machines will not produce power if run outside optimal RPM limits, see the above "RPM Sweetspots" table.
+These machines will not produce specification power if run outside optimal RPM limits, see the above "RPM Sweetspots" table.
+
+For instance, the MV generator will not produce specification power if the RPM exceeds ~3200 or falls below 3100 based on version 2.1.7 hardware. Running a MV generator at 5000 RPM will produce no power at all.
+
 
 ## Variants:
 ### LV

--- a/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
+++ b/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
@@ -22,7 +22,7 @@ TDB
 ### Efficiency notice:
 These machines will not produce specification power if run outside optimal RPM limits, see the above "RPM Sweetspots" table.
 
-For instance, the MV generator will not produce specification power if the RPM exceeds ~3200 or falls below 3100 based on version 2.1.7 hardware. Running a MV generator at 5000 RPM will produce no power at all.
+For instance, the MV generator will not produce specification power if the RPM exceeds ~3200 or falls below 3100 based on version 2.1.8 hardware. Running a MV generator at 5000 RPM will produce no power at all.
 
 
 ## Variants:

--- a/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
+++ b/docs/modules/ROOT/pages/buildings/modularpower/MP-Generators.adoc
@@ -20,8 +20,7 @@ TDB
 
 
 ### Efficiency notice:
-For maximum power generation efficiency, please operate this equipment within specified limits as described in the installer's manual.
-Failure to operate this equipment within documented limits will significantly reduce power generation capability and void the warranty.
+These machines will not produce power if run outside optimal RPM limits, see the above "RPM Sweetspots" table.
 
 ## Variants:
 ### LV


### PR DESCRIPTION
The present documentation doesn't  provide any clear advise to the effect of the "Recommended" operating RPM being the *required* RPM. This Pr fixes that by providing some text to this effect.

The reason this is necessary is its not at all evident that operating a MV turbine at maximum RPM would produce zero electrical energy. 
This issue doesn't manifest with the MK I turbine + LV generator, since the MK I turbine can't spin fast enough to break the LV turbine. Thus anyone upgrading to MK II turbines and MV generators may be in for an unexpected suprise as their power capacity falls away (due to misconfigured turbines) instead of climbing.