### PR TITLE
Update MP-Heaters.adoc

### DIFF
--- a/docs/modules/ROOT/pages/buildings/modularpower/MP-Heaters.adoc
+++ b/docs/modules/ROOT/pages/buildings/modularpower/MP-Heaters.adoc
@@ -15,7 +15,7 @@ The heater will produce Co2 which will need to be handled wither by venting thro
 
 | Coal Heater     | Coal              | ~20/Min     | ~75/Min    
 
-| Solution Heater | Fuel              | ~14/Min     | ~98/Min    
+| Solution Heater | Fuel              | ~7/Min     | ~56/Min    
 
 | Nuclear Heater  | Nuclear Fuel Rods | ~0.5/Min    | ~10/Min    
 |===


### PR DESCRIPTION
I am not sure if I am experiencing a bug with the mod but the boiler is only producing half the co2 and consuming half the fuel.
at least for the solution generator. i haven't tested whether this is across all modular heaters.
